### PR TITLE
v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## [2.1.1 (2024-10-27)](https://github.com/axe-api/axe-api/compare/2.1.1...2.1.0)
+
+- TypeError: list.map is not a function [#62](https://github.com/axe-api/validator/issues/62)
+
 ## [2.1.0 (2024-10-19)](https://github.com/axe-api/axe-api/compare/2.1.0...2.0.1)
 
 - Added `isRegistered()` function. [#60](https://github.com/axe-api/validator/issues/60)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "robust-validator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "robust-validator",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robust-validator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Rule-based data validation library",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/rules/isIn.ts
+++ b/src/rules/isIn.ts
@@ -1,4 +1,5 @@
-export default (value: any, list: any[]): boolean => {
+export default (value: any, options: any[] | string): boolean => {
+  const list: any[] = Array.isArray(options) ? options : options.split(",");
   const listAsString = list.map((item) => String(item).trim());
 
   if (Array.isArray(value)) {

--- a/src/rules/isNotIn.ts
+++ b/src/rules/isNotIn.ts
@@ -1,8 +1,9 @@
-export default (value: any, list: any[]): boolean => {
+export default (value: any, options: any[] | string): boolean => {
   if (value === null || value === undefined) {
     return false;
   }
 
+  const list: any[] = Array.isArray(options) ? options : options.split(",");
   const listAsString = list.map((item) => String(item).trim());
 
   if (Array.isArray(value)) {

--- a/tests/rules/in.test.ts
+++ b/tests/rules/in.test.ts
@@ -40,4 +40,8 @@ describe("isIn() ", () => {
     expect(isIn("A", ["a", "b", "c"])).toBe(false);
     expect(isIn("A", ["A", "B", "C"])).toBe(true);
   });
+
+  it("should be able to parse string values", async () => {
+    expect(isIn("A", "A,B,B")).toBe(true);
+  });
 });

--- a/tests/rules/notIn.test.ts
+++ b/tests/rules/notIn.test.ts
@@ -38,4 +38,9 @@ describe("isNotIn() ", () => {
     expect(isNotIn("A", ["a", "b", "c"])).toBe(true);
     expect(isNotIn("A", ["A", "B", "C"])).toBe(false);
   });
+
+  it("should be able to parse string values", async () => {
+    expect(isNotIn("A", "a,b,c")).toBe(true);
+    expect(isNotIn("A", "A,B,C")).toBe(false);
+  });
 });


### PR DESCRIPTION
## [2.1.1 (2024-10-27)](https://github.com/axe-api/axe-api/compare/2.1.1...2.1.0)

- TypeError: list.map is not a function [#62](https://github.com/axe-api/validator/issues/62)
