### PR TITLE
Fix `in:A,B,C`-rule validation by adding spread-support

### DIFF
--- a/src/rules/isIn.ts
+++ b/src/rules/isIn.ts
@@ -1,4 +1,10 @@
-export default (value: any, options: any[] | string): boolean => {
+export default (value: any, ...options: any): boolean => {
+  // support calls by "validate()" which uses spreading to pass all options.
+  // This behavior is different compared to standalone usage of this function.
+  if (options.length === 1) {
+    options = options[0]
+  }
+
   const list: any[] = Array.isArray(options) ? options : options.split(",");
   const listAsString = list.map((item) => String(item).trim());
 

--- a/tests/rules/in.test.ts
+++ b/tests/rules/in.test.ts
@@ -36,6 +36,11 @@ describe("isIn() ", () => {
     expect(isIn(["a", "b"], [])).toBe(false);
   });
 
+  it("should return false for empty options", () => {
+    expect(isIn("a")).toBe(false);
+    expect(isIn(["a", "b"])).toBe(false);
+  });
+
   it("should handle case sensitivity correctly", () => {
     expect(isIn("A", ["a", "b", "c"])).toBe(false);
     expect(isIn("A", ["A", "B", "C"])).toBe(true);
@@ -43,5 +48,10 @@ describe("isIn() ", () => {
 
   it("should be able to parse string values", async () => {
     expect(isIn("A", "A,B,B")).toBe(true);
+  });
+
+  it("should be able to work with spread-string options", async () => {
+    expect(isIn("A", ...["A,B,B"])).toBe(true);
+    expect(isIn("A", ...["A","B","C"])).toBe(true);
   });
 });


### PR DESCRIPTION
This MR adds spread-support for the in-rule.

I've discovered that `in:A,B,C` within `validate.ts` does only validate the first option (`A`) inside the list. This is due to the spread-usage `...[...rule.params, context]` inside `validate.ts`.

```
const isRuleValid = await rule.callback(
    check.value,
    ...[...rule.params, context]
);
```

basically calls the in-rule like that:

```
in('B', ...['A', 'B', 'C', {}])
```